### PR TITLE
docs: adjust list formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Invoke-WebRequest https://github.com/pyprojectx/pyprojectx/releases/latest/downl
 
 ## Project initialization
 Initialize a new or existing project with the _--init_ option (on Windows, replace `./pw` with `pw`):
+
 * `./pw --init project`: add pyprojectx example sections to an existing or new _pyproject.toml_ in the current directory.
 * `./pw --init pdm`: initialize a [PDM](https://pdm.fming.dev/) project and add pyprojectx example sections to _pyproject.toml_.
 * `./pw --init poetry`: initialize a [Poetry](https://python-poetry.org/) project and add pyprojectx example sections to _pyproject.toml_.

--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -62,10 +62,12 @@ with Poetry, or [px-demo](https://github.com/pyprojectx/px-demo) for an example 
 
 ## Github actions
 By using the `pw` wrapper script, you can simplify your github actions:
+
 * no explicitly tool installations or docker images (for Python tools)
 * use the same commands and scripts in github actions as on your laptop
 
 Some tips:
+
 * Use the same scripts on Linux and Windows by replacing `./pw` (resp. `.\pw`) with `python pw`
 * Speed up builds by caching `.pyprojectx`
 

--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -100,6 +100,7 @@ To install:
 
 ## Global tools
 Besides the `px` script, `pw --init global` also copies other files:
+
 * `pxg` script in `~/.pyprojectx`
 * `pw` script and example `pyproject.toml` in `~/.pyprojectx/global`
 


### PR DESCRIPTION
With `mkdocs`, lists need a line break after a paragraph to be formatted as lists. Otherwise, lists are formatted as part of the preceding paragraph:

<img width="811" alt="Screenshot 2023-06-07 at 10 13 02 AM" src="https://github.com/pyprojectx/pyprojectx/assets/865836/ddc98fa6-1de7-4449-99ef-c9ae0c6e47a2">

Most markdown previews don't show this, but it is a part of the markdown standard, such as it is. I think it's supposed to avoid accidentally rendering `*bold*` in a hard-wrapped wrapped paragraph as a list if there's an extra `* space*`.