### PR TITLE
(🐞) fix `--install-px`

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -83,10 +83,10 @@ With the wrapper scripts in place, you can generate example configuration (see [
 
     === "Linux/Mac"
         ```bash
-        ./pw --init global
+        ./pw --install-px
         ```
 
     === "Windows"
         ```powershell
-        .\pw --init global
+        .\pw --install-px
         ```

--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -90,16 +90,16 @@ This also works from subdirectories: `../../pw` can also be replaced with `px`
 To install:
 === "Linux/Mac"
     ```bash
-    ./pw --init global
+    ./pw --install-px
     ```
 
 === "Windows"
     ```powershell
-    .\pw --init global
+    .\pw --install-px
     ```
 
 ## Global tools
-Besides the `px` script, `pw --init global` also copies other files:
+Besides the `px` script, `pw --install-px` also copies other files:
 
 * `pxg` script in `~/.pyprojectx`
 * `pw` script and example `pyproject.toml` in `~/.pyprojectx/global`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyprojectx"
-version = "1.0.0.dev"
+version = "2.0.1.dev"
 description = "Execute scripts from pyproject.toml, installing tools on-the-fly"
 license = { text = "MIT" }
 authors = [{ name = "Houbie", email = "ivo@houbrechts-it.be" }]

--- a/src/pyprojectx/install_global.py
+++ b/src/pyprojectx/install_global.py
@@ -26,9 +26,12 @@ def install_px(options):
     global_dir.mkdir(parents=True, exist_ok=True)
 
     target_pw = global_dir.joinpath("pw")
-    if target_pw.exists() and "--force" not in options.cmd_args:
-        print(f"{target_pw} {BLUE} already exists, use '--init global --force' to overwrite{RESET}", file=sys.stderr)
-        return
+    print(options)
+    if target_pw.exists() and not options.force_install:
+        print(
+            f"{target_pw} {BLUE}already exists, use '--install-px --force-install' to overwrite{RESET}", file=sys.stderr
+        )
+        raise SystemExit(1)
 
     shutil.copy2(wrapper_dir.joinpath("pw.py"), target_pw)
     shutil.copy2(wrapper_dir.joinpath(f"px{SCRIPT_EXTENSION}"), global_dir.parent)
@@ -39,7 +42,7 @@ def install_px(options):
         "You can now start all your commands with 'px' in any subdirectory of your project instead of using './pw'",
         file=sys.stderr,
     )
-    if "skip-path" in options.cmd:
+    if options.cmd and "skip-path" in options.cmd:
         print(
             "Not adding the global pyprojectx directory to your PATH. You will need to add it manually.",
             file=sys.stderr,

--- a/src/pyprojectx/wrapper/pw.py
+++ b/src/pyprojectx/wrapper/pw.py
@@ -172,6 +172,8 @@ def ensure_pyprojectx(options):
                 f"{CYAN}installing pyprojectx {BLUE}{options.version}: {options.pyprojectx_package} {RESET}",
                 file=sys.stderr,
             )
+        if options.version == "development":
+            pip_cmd.append("-e")
         subprocess.run([*pip_cmd, options.pyprojectx_package], stdout=out, check=True)
     return pyprojectx_script
 

--- a/tests/integration/test_px.py
+++ b/tests/integration/test_px.py
@@ -33,6 +33,27 @@ def test_install_px(tmp_project):
     assert px_dir.joinpath(f"pxg{SCRIPT_EXTENSION}").exists()
 
 
+def test_install_px_force(tmp_project):
+    project_dir, env = tmp_project
+    cwd = project_dir.joinpath("global")
+    copy_px(cwd)
+    env["PYPROJECTX_HOME_DIR"] = str(cwd)
+    cmd = f"{SCRIPT_PREFIX}px --verbose --verbose --install-px "
+    # ensure px is already installed
+    subprocess.run(cmd + "skip-path", shell=True, cwd=cwd, env=env, check=False)
+
+    process = subprocess.run(
+        cmd + "skip-path", shell=True, cwd=cwd, env=env, check=False, capture_output=True, text=True
+    )
+    assert process.returncode == 1
+    assert "pw \033[94malready exists, use '--install-px --force-install' to overwrite" in process.stderr
+
+    process = subprocess.run(
+        cmd + "--force-install skip-path", shell=True, cwd=cwd, env=env, check=True, capture_output=True, text=True
+    )
+    assert "Global Pyprojectx scripts are installed in your home directory." in process.stderr
+
+
 def copy_px(dir_name):
     dir_name.mkdir(parents=True, exist_ok=True)
     shutil.copy(Path(__file__).parent.parent.joinpath(f"../src/pyprojectx/wrapper/px{SCRIPT_EXTENSION}"), dir_name)


### PR DESCRIPTION
Fixes many issues with `--install-px`:

- docs updated
- `--force` argument fixed (no idea why it was broken)
- fixed crash when `skip-path` wasn't supplied
- return code 1 when `--force` not supplied
- fix error message to not mention `--init`
- add test for `--force`

Additionally:
- updated version to 2.0.1.dev
- install development version as an editable install