### PR TITLE
install uv with its install script instead of using pip

### DIFF
--- a/bin/prep-release.py
+++ b/bin/prep-release.py
@@ -32,7 +32,7 @@ def replace_version_in_files(release_version):
 
     # replace __version__ in wrapper and pyproject.toml
     pw = Path("src/pyprojectx/wrapper/pw.py")
-    pw.write_text(pw.read_text().replace("__version__", release_version).replace("__uv_version__", uv_version))
+    pw.write_text(pw.read_text().replace("__version__", release_version).replace("__uv_version__", uv_version, 1))
     pyproject_content = re.sub(r'version\s*=\s*"\d.\d.\d.dev"', f'version = "{release_version}"', pyproject.read_text())
     pyproject.write_text(pyproject_content)
 

--- a/src/pyprojectx/wrapper/pw.py
+++ b/src/pyprojectx/wrapper/pw.py
@@ -169,16 +169,16 @@ def ensure_pyprojectx(options):
         xdg_bin_home = os.environ.get(uv_install_dir_env_var)
         os.environ[uv_install_dir_env_var] = str(uv_dir)
         os.environ["UV_NO_MODIFY_PATH"] = "1"
-        if sys.platform == "win32":
-            install_uv_cmd = (
-                "powershell -ExecutionPolicy Bypass -c "
-                f'"irm https://github.com/astral-sh/uv/releases/download/{UV_VERSION}/uv-installer.ps1 | iex"'
-            )
-        else:
-            install_uv_cmd = (
-                "curl --proto '=https' --tlsv1.2 -LsSf "
-                f"https://github.com/astral-sh/uv/releases/download/{UV_VERSION}/uv-installer.sh | sh"
-            )
+        release_base_url = (
+            "https://github.com/astral-sh/uv/releases/latest/download"
+            if UV_VERSION == "__uv_version__"
+            else f"https://github.com/astral-sh/uv/releases/download/{UV_VERSION}"
+        )
+        install_uv_cmd = (
+            f'powershell -ExecutionPolicy Bypass -c "irm {release_base_url}/uv-installer.ps1 | iex"'
+            if sys.platform == "win32"
+            else f"curl --proto '=https' --tlsv1.2 -LsSf irm {release_base_url}/uv-installer.sh | sh"
+        )
         venv_cmd = [uv, "venv", str(venv_dir), "--python", f"{sys.version_info.major}.{sys.version_info.minor}"]
         install_cmd = [uv, "pip", "install", "--pre", "--python", str(venv_dir / SCRIPTS_DIR / f"python{EXE}")]
         if options.quiet:

--- a/src/pyprojectx/wrapper/pw.py
+++ b/src/pyprojectx/wrapper/pw.py
@@ -168,6 +168,7 @@ def ensure_pyprojectx(options):
         uv_install_dir_env_var = "XDG_BIN_HOME"
         xdg_bin_home = os.environ.get(uv_install_dir_env_var)
         os.environ[uv_install_dir_env_var] = str(uv_dir)
+        os.environ["UV_NO_MODIFY_PATH"] = "1"
         if sys.platform == "win32":
             install_uv_cmd = (
                 "powershell -ExecutionPolicy Bypass -c "

--- a/src/pyprojectx/wrapper/pw.py
+++ b/src/pyprojectx/wrapper/pw.py
@@ -174,11 +174,11 @@ def ensure_pyprojectx(options):
             if UV_VERSION == "__uv_version__"
             else f"https://github.com/astral-sh/uv/releases/download/{UV_VERSION}"
         )
-        install_uv_cmd = (
-            f'powershell -ExecutionPolicy Bypass -c "irm {release_base_url}/uv-installer.ps1 | iex"'
-            if sys.platform == "win32"
-            else f"curl --proto '=https' --tlsv1.2 -LsSf irm {release_base_url}/uv-installer.sh | sh"
-        )
+        if sys.platform == "win32":
+            os.environ["PSMODULEPATH"] = "" # https://github.com/PowerShell/PowerShell/issues/18530#issuecomment-1325691850
+            install_uv_cmd = f'powershell -ExecutionPolicy Bypass -c "irm {release_base_url}/uv-installer.ps1 | iex"'
+        else:
+            install_uv_cmd = f"curl --proto '=https' --tlsv1.2 -LsSf irm {release_base_url}/uv-installer.sh | sh"
         venv_cmd = [uv, "venv", str(venv_dir), "--python", f"{sys.version_info.major}.{sys.version_info.minor}"]
         install_cmd = [uv, "pip", "install", "--pre", "--python", str(venv_dir / SCRIPTS_DIR / f"python{EXE}")]
         if options.quiet:


### PR DESCRIPTION
fixes #143

also fixes another issue i noticed. when the build script replaces `__uv_version__` it would also replace the `if UV_VERSION == "__uv_version__"` check which causes it to always return `True`