### PR TITLE
add powershell-specific `pw.ps1` wrapper script to fix parsing quoted arguments

### DIFF
--- a/bin/prep-release.py
+++ b/bin/prep-release.py
@@ -48,6 +48,7 @@ def zip_wrappers():
     with ZipFile("wrappers.zip", "w") as zip_file:
         zip_file.write("src/pyprojectx/wrapper/pw.py", "pw")
         zip_file.write("src/pyprojectx/wrapper/pw.bat", "pw.bat")
+        zip_file.write("src/pyprojectx/wrapper/pw.ps1", "pw.ps1")
 
 
 def generate_release_changelog():

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -82,7 +82,7 @@ With the wrapper scripts in place, you can start adding tools:
 !!! tip "Tip: Add the wrapper scripts to version control"
     When using Git:
     ```shell
-    git add pw pw.bat
+    git add pw pw.bat pw.ps1
     git update-index --chmod=+x pw
     echo .pyprojectx/ >> .gitignore
     ```

--- a/src/pyprojectx/wrapper/pw.ps1
+++ b/src/pyprojectx/wrapper/pw.ps1
@@ -1,0 +1,1 @@
+python "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)\pw" @args

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ def create_tmp_project(tmp_project_dir):
     shutil.copyfile(pyprojectx_project_dir / "src/pyprojectx/wrapper/pw.py", pw_copy)
     pw_copy.chmod(stat.S_IRWXU | stat.S_IRWXG)
     shutil.copy(pyprojectx_project_dir / "src/pyprojectx/wrapper/pw.bat", tmp_project_dir)
+    shutil.copy(pyprojectx_project_dir / "src/pyprojectx/wrapper/pw.ps1", tmp_project_dir)
     shutil.copytree(data_dir / "bin", tmp_project_dir / "bin")
     env = os.environ.copy()
     env["PYPROJECTX_PACKAGE"] = str(pyprojectx_project_dir.absolute())

--- a/tests/integration/test_pw.py
+++ b/tests/integration/test_pw.py
@@ -205,7 +205,9 @@ def test_cwd(tmp_project):
     assert Path(project_dir, f"{SCRIPT_PREFIX}pw").is_file()
     cmd = f"{SCRIPT_PREFIX}pw -q ls-projectdir"
     proc_result = subprocess.run(cmd, shell=True, capture_output=True, cwd=project_dir, env=env, check=True)
-    assert "pw.bat" in proc_result.stdout.decode("utf-8")
+    stdout = proc_result.stdout.decode("utf-8")
+    assert "pw.bat" in stdout
+    assert "pw.ps1" in stdout
 
     cmd = f"{SCRIPT_PREFIX}pw -q ls-pyprojectx"
     proc_result = subprocess.run(cmd, shell=True, capture_output=True, cwd=project_dir, env=env, check=True)


### PR DESCRIPTION
fixes #159 

i tested this on both a windows 10 and 11 machine and on both of them running the command works correctly when not running through `pw.bat`. i verified that adding this `pw.ps1` script fixes the issue